### PR TITLE
EDG-51: adding the quarkus bucket4j dependency for ratelimit support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
         <quarkus-opensearch.version>1.6.13</quarkus-opensearch.version>
         <org.eclipse.persistence.asm.version>9.7.0</org.eclipse.persistence.asm.version>
         <quarkus.opentelmetry.kafka.client.version>1.32.0-alpha</quarkus.opentelmetry.kafka.client.version>
+        <quarkus-bucket4j.version>1.0.4</quarkus-bucket4j.version>
     </properties>
 
     <dependencyManagement>
@@ -596,6 +597,11 @@
                 <groupId>io.quarkiverse.opensearch</groupId>
                 <artifactId>quarkus-opensearch-rest-high-level-client</artifactId>
                 <version>${quarkus-opensearch.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.bucket4j</groupId>
+                <artifactId>quarkus-bucket4j</artifactId>
+                <version>${quarkus-bucket4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
@sboeckelmann 

I am adding the `quarkus-bucket4j` dependency to the project to support API rate limit based on per user per group basis.
Please review and approve the PR.