### PR TITLE
GEN-306: migration from quarkus-websockets to quarkus-websockets-next

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -487,7 +487,7 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-websockets</artifactId>
+                <artifactId>quarkus-websockets-next</artifactId>
                 <version>${quarkus.platform.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -487,6 +487,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-websockets</artifactId>
+                <version>${quarkus.platform.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-websockets-next</artifactId>
                 <version>${quarkus.platform.version}</version>
             </dependency>


### PR DESCRIPTION
@sboeckelmann 

Please find the changes related to migration from `quarkus-websockets` to `quarkus-websockets-next`.
Kindly request you to review the changes and approve the PR.